### PR TITLE
reduce maximal size of one message to 8mb

### DIFF
--- a/varint.go
+++ b/varint.go
@@ -67,6 +67,7 @@ type varintReader struct {
 	next int
 	pool *mpool.Pool
 	lock sync.Locker
+	max  int // the maximal message size (in bytes) this reader handles
 }
 
 // NewVarintReader wraps an io.Reader with a varint msgio framed reader.
@@ -92,6 +93,7 @@ func NewVarintReaderWithPool(r io.Reader, p *mpool.Pool) ReadCloser {
 		next: -1,
 		pool: p,
 		lock: new(sync.Mutex),
+		max:  defaultMaxSize,
 	}
 }
 
@@ -141,8 +143,7 @@ func (s *varintReader) ReadMsg() ([]byte, error) {
 		return nil, err
 	}
 
-	// more then 512mb sounds exessive
-	if length > 512*1024*1024 {
+	if length > s.max {
 		return nil, ErrMsgTooLarge
 	}
 


### PR DESCRIPTION
per discussion in ipfs/go-ipfs#1181, reducing maximal message size to 8mb.