### PR TITLE
added MaxSize option to Reader

### DIFF
--- a/chan.go
+++ b/chan.go
@@ -32,7 +32,7 @@ func (s *Chan) ReadFrom(r io.Reader) {
 // ReadFromWithPool wraps the given io.Reader with a msgio.Reader, reads all
 // messages, ands sends them down the channel. Uses given Pool
 func (s *Chan) ReadFromWithPool(r io.Reader, p *mpool.Pool) {
-	s.readFrom(NewReaderWithPool(r, p))
+	s.readFrom(NewReader(r, Pool(p)))
 }
 
 // ReadFrom wraps the given io.Reader with a msgio.Reader, reads all

--- a/msgio_test.go
+++ b/msgio_test.go
@@ -3,12 +3,13 @@ package msgio
 import (
 	"bytes"
 	"fmt"
-	randbuf "github.com/jbenet/go-randbuf"
 	"io"
 	"math/rand"
 	"sync"
 	"testing"
 	"time"
+
+	randbuf "github.com/jbenet/go-randbuf"
 )
 
 func TestReadWrite(t *testing.T) {
@@ -178,5 +179,33 @@ func SubtestReadWriteMsgSync(t *testing.T, writer WriteCloser, reader ReadCloser
 
 	for e := range errs {
 		t.Error(e)
+	}
+}
+
+func TestReadMaxSize(t *testing.T) {
+	buf := new(bytes.Buffer)
+	writer := NewWriter(buf)
+	writer.WriteMsg(bytes.Repeat([]byte("x"), 11))
+	rd := NewReader(buf, MaxSize(10))
+	_, err := rd.ReadMsg()
+	if err == nil {
+		t.Fatal("should get an error")
+	}
+	if err != ErrMsgTooLarge {
+		t.Fatal("should return ErrMsgTooLarge")
+	}
+}
+
+func TestReadMaxSize_defaultSize(t *testing.T) {
+	buf := new(bytes.Buffer)
+	writer := NewWriter(buf)
+	writer.WriteMsg(bytes.Repeat([]byte("x"), defaultMaxSize+1))
+	rd := NewReader(buf)
+	_, err := rd.ReadMsg()
+	if err == nil {
+		t.Fatal("should get an error")
+	}
+	if err != ErrMsgTooLarge {
+		t.Fatal("should return ErrMsgTooLarge")
 	}
 }


### PR DESCRIPTION
I wanted to see how you feel about [functional options](http://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis) before I go through with it on the rest.

I think we should add an `error` return to the `NewXXX` constructors to signal illegal option usage.