### PR TITLE
fix for bounds errors on 32 bit systems

### DIFF
--- a/msgio.go
+++ b/msgio.go
@@ -177,6 +177,7 @@ func (s *reader) Read(msg []byte) (int, error) {
 	if length > len(msg) {
 		return 0, io.ErrShortBuffer
 	}
+
 	_, err = io.ReadFull(s.R, msg[:length])
 	s.next = -1 // signal we've consumed this msg
 	return length, err
@@ -191,7 +192,7 @@ func (s *reader) ReadMsg() ([]byte, error) {
 		return nil, err
 	}
 
-	if length > s.max {
+	if length > s.max || length < 0 {
 		return nil, ErrMsgTooLarge
 	}
 

--- a/msgio_test.go
+++ b/msgio_test.go
@@ -180,3 +180,18 @@ func SubtestReadWriteMsgSync(t *testing.T, writer WriteCloser, reader ReadCloser
 		t.Error(e)
 	}
 }
+
+func TestBadSizes(t *testing.T) {
+	data := make([]byte, 4)
+
+	// on a 64 bit system, this will fail because its too large
+	// on a 32 bit system, this will fail because its too small
+	NBO.PutUint32(data, 4000000000)
+	buf := bytes.NewReader(data)
+	read := NewReader(buf)
+	msg, err := read.ReadMsg()
+	if err == nil {
+		t.Fatal(err)
+	}
+	_ = msg
+}


### PR DESCRIPTION
on 32 bit systems, a number sent over the wire that is larger than max int32, but smaller than max uint32 will turn negative when cast as an int. This adds a simple check and test for this behaviour.